### PR TITLE
`yq` tool is available in the nix-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,9 @@
             config.treefmt.build.devShell
           ];
           nativeBuildInputs = [
-            pkgs.nodejs
             pkgs.just
+            pkgs.nodejs
+            pkgs.yq-go
           ];
         };
       };


### PR DESCRIPTION
`pkgs.yq-go` is the one the `download-prs.sh` script [needs](https://github.com/IntersectMBO/cardano-updates/blob/1592343330b055f332ee5989e8a17befcdce3e16/scripts/download-prs.sh#L5) (https://github.com/mikefarah/yq/), not the `pkgs.yq` (https://github.com/kislyuk/yq)