### PR TITLE
network-update: serve videos from google

### DIFF
--- a/blog/2024-07-19-network.md
+++ b/blog/2024-07-19-network.md
@@ -20,15 +20,12 @@ audience.
 
 ### Introduction to Ouroboros Network, NWG, part 1
 
-```mdx-code-block
-<ReactPlayer controls url='/images/network/NWG-part1.mp4' />
-```
+<iframe src="https://drive.google.com/file/d/1J_o2iGy4jeIR6X1x9D6p_nHKLCNjgX6h/preview" width="640" height="480"></iframe>
 
 ### Introduction to Ouroboros Network, NWG, part 2
 
-```mdx-code-block
-<ReactPlayer controls url='/images/network/NWG-part2.mp4' />
-```
+<iframe src="https://drive.google.com/file/d/1CsqC1R_GMliWkKJaeSCf-xrZG6F6yvMv/preview" width="640" height="480"></iframe>
+<iframe src="https://drive.google.com/file/d/1QV46QqmpkfPVcoKxueYHg4Qe7rPQzOer/preview" width="640" height="480"></iframe>
 
 ### Tx-Submission
 

--- a/static/images/network/NWG-part1.mp4
+++ b/static/images/network/NWG-part1.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6dd86fbe2badc5dfec8872d5ae877aab42cc226d67ae1cf5c514b6d54f0c3da
-size 187747890

--- a/static/images/network/NWG-part2.mp4
+++ b/static/images/network/NWG-part2.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf8b93f2f62c571830aa2b6cca9ae25ebd9c1f66c4f9fc2a63783239870b800b
-size 256643025


### PR DESCRIPTION
GitHub doesn't suport Git's LFS on GitHub Pages:
https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage
