### PR TITLE
network-update: updated PR state

### DIFF
--- a/blog/2025-02-19-network.md
+++ b/blog/2025-02-19-network.md
@@ -18,10 +18,10 @@ was the largest in our queue.
 ```mermaid
 flowchart TD;
   SRV[SRV implementation]:::open
-  E[Mux: bind threads to a capability]:::open
+  E[Mux: bind threads to a capability]:::merged
   D[<b>Peer Selection Exports</b>]:::open
   C[Public Network State]:::open
-  B[Drop NonP2P Components]:::open
+  B[Drop NonP2P Components]:::merged
   A[Extensible Ouroboros Network Components]:::merged
   MAIN[main]
   ouroboros-network-0.19


### PR DESCRIPTION
It would be nice to have a GitHub link component which renders links to
PRs in a standard way.
